### PR TITLE
test: Add comparison of return value for `ft_snprintf` tests

### DIFF
--- a/bonus/real-tests/ft_printf/01_stdout_string_bonus.c
+++ b/bonus/real-tests/ft_printf/01_stdout_string_bonus.c
@@ -1,23 +1,26 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   01_string_bonus.c                                  :+:      :+:    :+:   */
+/*   01_stdout_string_bonus.c                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:11 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 23:21:34 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:17:32 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
-#include <string.h>
+#include <stdio.h>
 
 int	stdout_string(void)
 {
-	const char	*test_string = "test_string";
+	int	ft_ret;
+	int	og_ret;
 
-	if ((size_t) ft_printf("%s", test_string) == strlen(test_string))
+	ft_ret = ft_printf("%s", "test_string");
+	og_ret = snprintf(NULL, 0, "%s", "test_string");
+	if (ft_ret == og_ret)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/02_stdout_width_bonus.c
+++ b/bonus/real-tests/ft_printf/02_stdout_width_bonus.c
@@ -6,17 +6,15 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:15 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 23:30:58 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 09:58:46 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
-#include <stdio.h>
-#include <string.h>
 
 int	stdout_width(void)
 {
-	if ((size_t) ft_printf("%32s", "test_string") == 32)
+	if (ft_printf("%32s", "test_string") == 32)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/02_stdout_width_bonus.c
+++ b/bonus/real-tests/ft_printf/02_stdout_width_bonus.c
@@ -6,15 +6,21 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:15 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:58:46 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:17:38 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
+#include <stdio.h>
 
 int	stdout_width(void)
 {
-	if (ft_printf("%32s", "test_string") == 32)
+	int	ft_ret;
+	int	og_ret;
+
+	ft_ret = ft_printf("%32s", "test_string");
+	og_ret = snprintf(NULL, 0, "%32s", "test_string");
+	if (ft_ret == og_ret)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/03_stdout_left_aligned_bonus.c
+++ b/bonus/real-tests/ft_printf/03_stdout_left_aligned_bonus.c
@@ -6,17 +6,15 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:17 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 23:53:41 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 09:58:52 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
-#include <stdio.h>
-#include <string.h>
 
 int	stdout_left_aligned(void)
 {
-	if ((size_t) ft_printf("%-32s", "test_string") == 32)
+	if (ft_printf("%-32s", "test_string") == 32)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/03_stdout_left_aligned_bonus.c
+++ b/bonus/real-tests/ft_printf/03_stdout_left_aligned_bonus.c
@@ -6,15 +6,21 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:17 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:58:52 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:17:42 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
+#include <stdio.h>
 
 int	stdout_left_aligned(void)
 {
-	if (ft_printf("%-32s", "test_string") == 32)
+	int	ft_ret;
+	int	og_ret;
+
+	ft_ret = ft_printf("%-32s", "test_string");
+	og_ret = snprintf(NULL, 0, "%-32s", "test_string");
+	if (ft_ret == og_ret)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/04_stdout_precision_bonus.c
+++ b/bonus/real-tests/ft_printf/04_stdout_precision_bonus.c
@@ -6,17 +6,15 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:19 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 23:58:07 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 09:58:58 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
-#include <stdio.h>
-#include <string.h>
 
 int	stdout_precision(void)
 {
-	if ((size_t) ft_printf("%-32.4s", "test_string") == 32)
+	if (ft_printf("%-32.4s", "test_string") == 32)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/04_stdout_precision_bonus.c
+++ b/bonus/real-tests/ft_printf/04_stdout_precision_bonus.c
@@ -6,15 +6,21 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:19 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:58:58 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:17:45 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
+#include <stdio.h>
 
 int	stdout_precision(void)
 {
-	if (ft_printf("%-32.4s", "test_string") == 32)
+	int	ft_ret;
+	int	og_ret;
+
+	ft_ret = ft_printf("%-32.4s", "test_string");
+	og_ret = snprintf(NULL, 0, "%-32.4s", "test_string");
+	if (ft_ret == og_ret)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/05_stdout_asterisk_bonus.c
+++ b/bonus/real-tests/ft_printf/05_stdout_asterisk_bonus.c
@@ -6,17 +6,15 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:21 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 23:59:35 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 09:59:03 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
-#include <stdio.h>
-#include <string.h>
 
 int	stdout_asterisk(void)
 {
-	if ((size_t) ft_printf("%-*.*s", 32, 4, "test_string") == 32)
+	if (ft_printf("%-*.*s", 32, 4, "test_string") == 32)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/05_stdout_asterisk_bonus.c
+++ b/bonus/real-tests/ft_printf/05_stdout_asterisk_bonus.c
@@ -6,15 +6,21 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:21 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:59:03 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:17:49 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
+#include <stdio.h>
 
 int	stdout_asterisk(void)
 {
-	if (ft_printf("%-*.*s", 32, 4, "test_string") == 32)
+	int	ft_ret;
+	int	og_ret;
+
+	ft_ret = ft_printf("%-*.*s", 32, 4, "test_string");
+	og_ret = snprintf(NULL, 0, "%-*.*s", 32, 4, "test_string");
+	if (ft_ret == og_ret)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_printf/06_stdout_all_features_bonus.c
+++ b/bonus/real-tests/ft_printf/06_stdout_all_features_bonus.c
@@ -6,17 +6,26 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:23 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:49:53 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:25:15 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft/ft_printf.h"
 #include <limits.h>
+#include <stdio.h>
 
 int	stdout_all_features(void)
 {
-	if (ft_printf("%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
-		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0) == 79)
+	int	ft_ret;
+	int	og_ret;
+
+	ft_ret = ft_printf(
+		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
+		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
+	og_ret = snprintf(NULL, 0, 
+		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
+		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
+	if (ft_ret == og_ret)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/00_launcher_bonus.c
+++ b/bonus/real-tests/ft_snprintf/00_launcher_bonus.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:40:59 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:27:20 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:45:59 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,5 +22,6 @@ void	ft_snprintf_launcher(t_libunit *libunit)
 	libunit_load(libunit, "precision", precision);
 	libunit_load(libunit, "asterisk", asterisk);
 	libunit_load(libunit, "all_features", all_features);
+	libunit_load(libunit, "null_buffer", null_buffer);
 	libunit_launch(libunit);
 }

--- a/bonus/real-tests/ft_snprintf/01_string_bonus.c
+++ b/bonus/real-tests/ft_snprintf/01_string_bonus.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   01_string.c                                        :+:      :+:    :+:   */
+/*   01_string_bonus.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:11 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:12 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:23:12 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	string(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/02_width_bonus.c
+++ b/bonus/real-tests/ft_snprintf/02_width_bonus.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   02_width.c                                         :+:      :+:    :+:   */
+/*   02_width_bonus.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:15 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:16 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:23:25 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	width(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%32s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%32s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%32s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%32s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/03_left_aligned_bonus.c
+++ b/bonus/real-tests/ft_snprintf/03_left_aligned_bonus.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   03_left_aligned.c                                  :+:      :+:    :+:   */
+/*   03_left_aligned_bonus.c                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:17 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:18 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:23:34 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	left_aligned(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%-32s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%-32s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%-32s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%-32s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/04_precision_bonus.c
+++ b/bonus/real-tests/ft_snprintf/04_precision_bonus.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   04_precision.c                                     :+:      :+:    :+:   */
+/*   04_precision_bonus.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:19 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:20 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:23:49 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	precision(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%-32.4s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%-32.4s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%-32.4s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%-32.4s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/05_asterisk_bonus.c
+++ b/bonus/real-tests/ft_snprintf/05_asterisk_bonus.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   05_asterisk.c                                      :+:      :+:    :+:   */
+/*   05_asterisk_bonus.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:21 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:22 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:26:04 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	asterisk(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%-*.*s", 32, 4, "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%-*.*s", 32, 4, "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%-*.*s", 32, 4, "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%-*.*s", 32, 4, "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/06_all_features_bonus.c
+++ b/bonus/real-tests/ft_snprintf/06_all_features_bonus.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:23 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:53:34 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:24:54 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,14 +19,16 @@ int	all_features(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), 
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
 		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
 		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
-	snprintf(og_buffer, sizeof(og_buffer), 
+	og_ret = snprintf(og_buffer, sizeof(og_buffer), 
 		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
 		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/bonus/real-tests/ft_snprintf/07_null_buffer_bonus.c
+++ b/bonus/real-tests/ft_snprintf/07_null_buffer_bonus.c
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   07_null_buffer_bonus.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/06 07:41:23 by ldulling          #+#    #+#             */
+/*   Updated: 2025/07/10 10:45:30 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft/ft_printf.h"
+#include <limits.h>
+#include <stdio.h>
+
+int	null_buffer(void)
+{
+	int		ft_ret;
+	int		og_ret;
+
+	ft_ret = ft_snprintf(NULL, 0,
+		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
+		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
+	og_ret = snprintf(NULL, 0, 
+		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
+		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
+	if (ft_ret == og_ret)
+		return (0);
+	return (-1);
+}

--- a/bonus/real-tests/ft_snprintf/sourcelist.mk
+++ b/bonus/real-tests/ft_snprintf/sourcelist.mk
@@ -6,4 +6,5 @@ SRC	+=	$(addprefix ft_snprintf/, \
 		04_precision_bonus.c \
 		05_asterisk_bonus.c \
 		06_all_features_bonus.c \
+		07_null_buffer_bonus.c \
 )

--- a/bonus/real-tests/ft_snprintf/tests_bonus.h
+++ b/bonus/real-tests/ft_snprintf/tests_bonus.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/05 08:29:59 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:27:33 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:45:40 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,5 +19,6 @@ int	left_aligned(void);
 int	precision(void);
 int	asterisk(void);
 int	all_features(void);
+int	null_buffer(void);
 
 #endif

--- a/real-tests/ft_snprintf/00_launcher.c
+++ b/real-tests/ft_snprintf/00_launcher.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:40:59 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:16:54 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:46:42 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,5 +22,6 @@ void	ft_snprintf_launcher(t_libunit *libunit)
 	libunit_load(libunit, "precision", precision);
 	libunit_load(libunit, "asterisk", asterisk);
 	libunit_load(libunit, "all_features", all_features);
+	libunit_load(libunit, "null_buffer", null_buffer);
 	libunit_launch(libunit);
 }

--- a/real-tests/ft_snprintf/01_string.c
+++ b/real-tests/ft_snprintf/01_string.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:11 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:12 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:31:22 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	string(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/real-tests/ft_snprintf/02_width.c
+++ b/real-tests/ft_snprintf/02_width.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:15 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:16 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:31:26 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	width(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%32s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%32s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%32s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%32s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/real-tests/ft_snprintf/03_left_aligned.c
+++ b/real-tests/ft_snprintf/03_left_aligned.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:17 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:18 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:31:31 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	left_aligned(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%-32s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%-32s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%-32s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%-32s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/real-tests/ft_snprintf/04_precision.c
+++ b/real-tests/ft_snprintf/04_precision.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:19 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:20 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:31:37 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	precision(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%-32.4s", "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%-32.4s", "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%-32.4s", "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%-32.4s", "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/real-tests/ft_snprintf/05_asterisk.c
+++ b/real-tests/ft_snprintf/05_asterisk.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:21 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/06 07:41:22 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:31:44 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,14 @@ int	asterisk(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), "%-*.*s", 32, 4, "test_string");
-	snprintf(og_buffer, sizeof(og_buffer), "%-*.*s", 32, 4, "test_string");
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
+		"%-*.*s", 32, 4, "test_string");
+	og_ret = snprintf(og_buffer, sizeof(og_buffer),
+		"%-*.*s", 32, 4, "test_string");
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/real-tests/ft_snprintf/06_all_features.c
+++ b/real-tests/ft_snprintf/06_all_features.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/06 07:41:23 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:45:25 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:31:54 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,14 +19,16 @@ int	all_features(void)
 {
 	char	ft_buffer[128];
 	char	og_buffer[128];
+	int		ft_ret;
+	int		og_ret;
 
-	ft_snprintf(ft_buffer, sizeof(ft_buffer), 
+	ft_ret = ft_snprintf(ft_buffer, sizeof(ft_buffer),
 		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
 		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
-	snprintf(og_buffer, sizeof(og_buffer), 
+	og_ret = snprintf(og_buffer, sizeof(og_buffer), 
 		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
 		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
-	if (strcmp(ft_buffer, og_buffer) == 0)
+	if (ft_ret == og_ret && strcmp(ft_buffer, og_buffer) == 0)
 		return (0);
 	return (-1);
 }

--- a/real-tests/ft_snprintf/07_null_buffer.c
+++ b/real-tests/ft_snprintf/07_null_buffer.c
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   07_null_buffer.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/07/06 07:41:23 by ldulling          #+#    #+#             */
+/*   Updated: 2025/07/10 10:44:50 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft/ft_printf.h"
+#include <limits.h>
+#include <stdio.h>
+
+int	null_buffer(void)
+{
+	int		ft_ret;
+	int		og_ret;
+
+	ft_ret = ft_snprintf(NULL, 0,
+		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
+		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
+	og_ret = snprintf(NULL, 0, 
+		"%-2c %-4.2s-%-9p+%+01d#%- .0i.%-*.*u0%0#4x1%#-3.X%%*",
+		'.', "", NULL, INT_MIN, INT_MAX, 10, 20, UINT_MAX, UINT_MAX, 0);
+	if (ft_ret == og_ret)
+		return (0);
+	return (-1);
+}

--- a/real-tests/ft_snprintf/sourcelist.mk
+++ b/real-tests/ft_snprintf/sourcelist.mk
@@ -6,4 +6,5 @@ SRC	+=	$(addprefix ft_snprintf/, \
 		04_precision.c \
 		05_asterisk.c \
 		06_all_features.c \
+		07_null_buffer.c \
 )

--- a/real-tests/ft_snprintf/tests.h
+++ b/real-tests/ft_snprintf/tests.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/05 08:29:59 by ldulling          #+#    #+#             */
-/*   Updated: 2025/07/10 09:16:58 by ldulling         ###   ########.fr       */
+/*   Updated: 2025/07/10 10:46:53 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,5 +19,6 @@ int	left_aligned(void);
 int	precision(void);
 int	asterisk(void);
 int	all_features(void);
+int	null_buffer(void);
 
 #endif


### PR DESCRIPTION
- Compare `ft_printf` return value with `snprintf` instead of hardcoding an expected number.
- Add comparison of return value for `ft_snprintf` tests
- Add a null buffer test for `ft_snprintf`

---

- Depends on #27.